### PR TITLE
feat: add support for bridging gaps between different languages

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -56,7 +56,12 @@
 
 
   </section>
-  {{ if gt .Pages 0 }}
+  {{ $pages := .Pages }}
+  {{ range .Translations }}
+    {{$pages = $pages | lang.Merge .Pages}}
+  {{ end }}
+
+  {{ if gt $pages 0 }}
 
     {{ $cardView := .Params.cardView | default (.Site.Params.list.cardView | default false) }}
     {{ $cardViewScreenWidth := .Params.cardViewScreenWidth | default (.Site.Params.list.cardViewScreenWidth | default false) }}
@@ -68,7 +73,7 @@
 
     <section class="space-y-10 w-full">
       {{ if not $orderByWeight }}
-        {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
+        {{ range (.Paginate ($pages.GroupByDate "2006")).PageGroups }}
         {{ if $groupByYear }}
         <h2 class="mt-12 text-2xl font-bold text-neutral-700 first:mt-8 dark:text-neutral-300">
           {{ .Key }}
@@ -79,7 +84,7 @@
         {{ end }}
         {{ end }}
       {{ else }}
-        {{ range (.Paginate (.Pages.ByWeight)).Pages }}
+        {{ range (.Paginate ($pages.ByWeight)).Pages }}
         {{ partial "article-link/simple.html" . }}
         {{ end }}
       {{ end }}
@@ -89,7 +94,7 @@
 
       {{ if $groupByYear }}
 
-      {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
+      {{ range (.Paginate ($pages.GroupByDate "2006")).PageGroups }}
         {{ if $cardViewScreenWidth }}
         <div class="relative w-screen max-w-[1600px] px-[30px]" style="left: calc(max(-50vw,-800px) + 50%);">
         {{ end }}
@@ -113,13 +118,13 @@
         <section class="w-full grid gap-4 sm:grid-cols-2 md:grid-cols-3">
         {{ end }}
         {{ if not $orderByWeight }}
-          {{ range (.Paginate (.Pages.GroupByDate "2006")).PageGroups }}
+          {{ range (.Paginate ($pages.GroupByDate "2006")).PageGroups }}
           {{ range .Pages }}
           {{ partial "article-link/card.html" . }}
           {{ end }}
           {{ end }}
         {{ else }}
-          {{ range (.Paginate (.Pages.ByWeight)).Pages }}
+          {{ range (.Paginate ($pages.ByWeight)).Pages }}
           {{ partial "article-link/card.html" . }}
           {{ end }}
         {{ end }}


### PR DESCRIPTION
## Description

I have used `Translation` with `lang.Merge` to bridge the gap between different languages when a specific language version does not exist. For example, if you have the following blogs:

- `blog.1.en`
- `blog.1.ch`
- `blog.2.en`

When you check the English blogs, you will see:

- `blog.1.en`
- `blog.2.en`

When you check the Chinese blogs, you will see:

- `blog.1.ch`
- `blog.2.en`


